### PR TITLE
fixed pickup issue

### DIFF
--- a/lua/weapons/weapon_portalgun.lua
+++ b/lua/weapons/weapon_portalgun.lua
@@ -107,7 +107,7 @@ end
 
 hook.Add('AllowPlayerPickup', 'DisallowPickup', function(ply, ent)
     local hasgun = IsValid(ply:GetActiveWeapon()) and ply:GetActiveWeapon():GetClass() == 'weapon_portalgun'
-    if hasgun and not IsPickable(ent) then return false end
+    if not hasgun or not IsPickable(ent) then return false end
 
     return true
 end)


### PR DESCRIPTION
This pull request fixes the issue which was reported in the Steam Workshop comments.
Weapons can now be picked up normally without any issues no matter if the portalgun is equipped or not.
The portalgun can still pick props like chairs and crates up but no weapons.
It was tested and seemed to work like it should.