### PR TITLE
fix spectators/specdm users can use portal

### DIFF
--- a/lua/entities/portalgun_portal.lua
+++ b/lua/entities/portalgun_portal.lua
@@ -313,6 +313,7 @@ end
 
 function ENT:TeleportEntityToPortal(ent, portal)
     if CLIENT then return end
+    if ent:IsSpec() or SpecDM and (ent.IsGhost and ent:IsGhost()) then return end
     local volume = 1
 
     if (not ent:IsPlayer()) then


### PR DESCRIPTION
This pull request fixes the issue in which spectators and SpecDM users could use a portal which also caused the sound effect to be played.
Now only the living ones can use a portal.
This was tested and seemed to work as expected.